### PR TITLE
fix: docker on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # consolidated project Dockerfile
-FROM node:22
+FROM node:18
 
 # set working directory
 WORKDIR /app
@@ -10,7 +10,7 @@ COPY package-lock.json ./
 COPY frontend/package.json ./frontend/
 COPY backend/package.json ./backend/
 
-# clean install dependencies
+# install dependencies
 RUN npm ci
 
 # copy the rest of the project files
@@ -18,3 +18,6 @@ COPY . .
 
 # expose ports for frontend, backend
 EXPOSE 5173 3000
+
+# start the dev servers at the end of the build to keep compose file clean
+CMD ["npm", "run", "dev"]

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,5 +52,7 @@ app.use(fallbackErrorHandler);
 
 // Start the server and listen on port defined in .env file
 app.listen(PORT, () => {
-  console.log('\nPalette started!\n\nAccess the application at http://localhost:5173');
+  console.log(
+    "\nPalette started!\n\nAccess the application at http://localhost:5173",
+  );
 });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,5 +52,5 @@ app.use(fallbackErrorHandler);
 
 // Start the server and listen on port defined in .env file
 app.listen(PORT, () => {
-  console.log(`Server is up on port: ${PORT}`);
+  console.log('\nPalette started!\n\nAccess the application at http://localhost:5173');
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+
 services:
   app:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:password@db:5432/palette-db
       - NODE_ENV=development
-    command: sh -c "npm run dev && echo 'Application started successfully, access it at https://localhost:5173'"
+    command: sh -c "npm run dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "3000:3000" # map the backend port
     volumes:
       - .:/app # mounts project files for live changes without needing to rebuild container
+      - /app/node_modules # isolate container's node_modules directory from the host
     environment:
       - DATABASE_URL=postgres://postgres:password@db:5432/palette-db
       - NODE_ENV=development
-    command: sh -c "npm run clean && npm run dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:password@db:5432/palette-db
       - NODE_ENV=development
-    command: sh -c "npm run dev"
+    command: sh -c "npm run clean && npm run dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:password@db:5432/palette-db
       - NODE_ENV=development
+    command: sh -c "npm run dev && echo 'Application started successfully, access it at https://localhost:5173'"


### PR DESCRIPTION
Changes to ensure the container dependencies are completely isolated from the host to avoid issues with trying to run mac binaries on linux, etc. 

Also updated the container to run Node 18 which is the predominant LTS release.

Closes #186  (see for more details on the fix)