### PR TITLE
feature: apply default course filter

### DIFF
--- a/palette-types/src/canvasTypes/CanvasCourse.ts
+++ b/palette-types/src/canvasTypes/CanvasCourse.ts
@@ -39,14 +39,14 @@ export interface CanvasCourse {
   template: boolean;
   sis_course_id?: string;
   integration_id?: string | null;
-  enrollments?: Array<{
+  enrollments: {
     type: "student" | "teacher" | "ta" | "observer" | "designer";
     role: string;
     role_id: number;
     user_id: number;
     enrollment_state: "active" | "invited" | "inactive";
     limit_privileges_to_course_section?: boolean;
-  }>;
+  }[];
   hide_final_grades: boolean;
   workflow_state: "unpublished" | "available" | "completed" | "deleted";
   course_format: "online" | "on_campus" | "blended";


### PR DESCRIPTION
- if there are more than 5 courses the user is a ta or grader for, filter by courses that are in current calendar year
- placeholder until custom filters for course and assignment fetching are implemented
- the 5 course threshold keeps things usable for the development team with the shell's start date being in 2019
- #230